### PR TITLE
Buffer the last 10 reads from the pty, and play back to new clients

### DIFF
--- a/terminado/websocket.py
+++ b/terminado/websocket.py
@@ -92,6 +92,8 @@ class TermSocket(tornado.websocket.WebSocketHandler):
         url_component = _cast_unicode(url_component)
         self.term_name = url_component or 'tty'
         self.terminal = self.term_manager.get_terminal(url_component)
+        for s in self.terminal.read_buffer:
+            self.on_pty_read(s)
         self.terminal.clients.append(self)
 
         self.send_json_message(["setup", {}])


### PR DESCRIPTION
This should mitigate #4

@payne92, do you have time to install this branch and test it out with IPython? It should ensure that at least the most recent prompt is always shown when a new client is connected.