### PR TITLE
Make built wheels universal.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[bdist_wheel]
+universal=True


### PR DESCRIPTION
Terminado currently doesn't have wheels on pypi. This patch makes uploaded wheels universal (one wheel for python 2 and 3).