### PR TITLE
Revert pinging implementation, and call super method in websocket open

### DIFF
--- a/terminado/websocket.py
+++ b/terminado/websocket.py
@@ -48,14 +48,7 @@ def _cast_unicode(s):
 
 class TermSocket(tornado.websocket.WebSocketHandler):
     """Handler for a terminal websocket"""
-    def initialize(self, term_manager, keep_alive_time=0):
-        """
-        keep_alive_time - if there is no activity for x seconds specified in keep_alive_time,
-                          a websocket ping message will be sent. Default is 0. Set it to 0 to
-                          disable sending the ping message. This feature is used to keep proxies 
-                          such as nginx from automatically closing the connection when there is 
-                          no activity.
-        """
+    def initialize(self, term_manager):
         self.term_manager = term_manager
         self.term_name = ""
         self.size = (None, None)
@@ -63,26 +56,6 @@ class TermSocket(tornado.websocket.WebSocketHandler):
 
         self._logger = logging.getLogger(__name__)
 
-        #send a ping if there is no activity for more than this many of seconds
-        self.keep_alive_time = keep_alive_time 
-        self.last_activity_time = 0
-    
-    def __timer(self):
-        if self.ws_connection is not None:
-            io_loop = self.ws_connection.stream.io_loop
-            t = io_loop.time()
-            if t - self.last_activity_time > self.keep_alive_time:
-                self.ping(b"ping")
-                #logging.debug('websocket ping')
-                self.last_activity_time = t
-            io_loop.add_timeout(max(0.2*self.keep_alive_time, 0.25), self.__timer) 
-                
-    def __update_last_activity_time(self):
-        if self.ws_connection is not None:
-            io_loop = self.ws_connection.stream.io_loop
-            t = io_loop.time()
-            self.last_activity_time = t
-            
     def origin_check(self, origin=None):
         """Deprecated: backward-compat for terminado <= 0.5."""
         return self.check_origin(origin or self.request.headers.get('Origin'))
@@ -104,25 +77,16 @@ class TermSocket(tornado.websocket.WebSocketHandler):
         self.terminal.clients.append(self)
 
         self.send_json_message(["setup", {}])
-        
-        if self.keep_alive_time>0:
-            self.__update_last_activity_time()
-            io_loop = self.ws_connection.stream.io_loop            
-            io_loop.add_timeout(max(0.2*self.keep_alive_time, 0.25), self.__timer)        
-            
         self._logger.info("TermSocket.open: Opened %s", self.term_name)
-    
+
     def on_pty_read(self, text):
         """Data read from pty; send to frontend"""
         self.send_json_message(['stdout', text])
-      
 
     def send_json_message(self, content):
         json_msg = json.dumps(content)
         self.write_message(json_msg)
-        if self.keep_alive_time>0:
-            self.__update_last_activity_time()
-        
+
     def on_message(self, message):
         """Handle incoming websocket message
         
@@ -130,8 +94,6 @@ class TermSocket(tornado.websocket.WebSocketHandler):
         what kind of message this is. Data associated with the message follows.
         """
         ##logging.info("TermSocket.on_message: %s - (%s) %s", self.term_name, type(message), len(message) if isinstance(message, bytes) else message[:250])
-        if self.keep_alive_time>0:
-            self.__update_last_activity_time()
         command = json.loads(message)
         msg_type = command[0]    
 

--- a/terminado/websocket.py
+++ b/terminado/websocket.py
@@ -66,6 +66,9 @@ class TermSocket(tornado.websocket.WebSocketHandler):
         Call our terminal manager to get a terminal, and connect to it as a
         client.
         """
+        # Jupyter has a mixin to ping websockets and keep connections through
+        # proxies alive. Call super() to allow that to set up:
+        super(TermSocket, self).open(url_component)
 
         self._logger.info("TermSocket.open: %s", url_component)
 


### PR DESCRIPTION
This should allow terminals in Jupyter to use the websocket pinging implemented by a mixin class.

Ping @minrk @zyzhu2000