### PR TITLE
Include LICENSE.txt file in the tarball

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 include README.rst
+include LICENSE.txt


### PR DESCRIPTION
The PyPI tarball is missing a license file, please add it.